### PR TITLE
Add helm charts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,3 +142,22 @@ Run the ``generate_keys.sh`` script to create a ``keys`` folder with all the nee
 
   ./generate_keys.sh
 
+Deployment with Helm
+====================
+
+Installation
+-----------
+
+In the following examples we use the `development` namespace. The values.yaml currently contains values for development.
+
+.. sourcecode:: shell
+
+  helm install --debug --name discovery --namespace development charts/nuts-discovery -f charts/nuts-discovery/values.yaml
+
+Upgrading
+---------
+
+.. sourcecode:: shell
+
+  helm upgrade discovery -f charts/nuts-discovery/values.yaml charts/nuts-discovery --namespace development --recreate-pods
+

--- a/charts/nuts-discovery/.helmignore
+++ b/charts/nuts-discovery/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/nuts-discovery/Chart.yaml
+++ b/charts/nuts-discovery/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: nuts-discovery
+version: 0.1.0

--- a/charts/nuts-discovery/templates/NOTES.txt
+++ b/charts/nuts-discovery/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "nuts-discovery.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "nuts-discovery.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "nuts-discovery.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "nuts-discovery.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/charts/nuts-discovery/templates/_helpers.tpl
+++ b/charts/nuts-discovery/templates/_helpers.tpl
@@ -1,0 +1,56 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nuts-discovery.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nuts-discovery.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nuts-discovery.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "nuts-discovery.labels" -}}
+app.kubernetes.io/name: {{ include "nuts-discovery.name" . }}
+helm.sh/chart: {{ include "nuts-discovery.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "nuts-discovery.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "nuts-discovery.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/nuts-discovery/templates/deployment.yaml
+++ b/charts/nuts-discovery/templates/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "nuts-discovery.fullname" . }}
+  labels:
+{{ include "nuts-discovery.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "nuts-discovery.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "nuts-discovery.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ template "nuts-discovery.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+#          livenessProbe:
+#            httpGet:
+#              path: /
+#              port: http
+#          readinessProbe:
+#            httpGet:
+#              path: /
+#              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/nuts-discovery/templates/ingress.yaml
+++ b/charts/nuts-discovery/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "nuts-discovery.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+{{ include "nuts-discovery.labels" . | indent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/nuts-discovery/templates/service.yaml
+++ b/charts/nuts-discovery/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nuts-discovery.fullname" . }}
+  labels:
+{{ include "nuts-discovery.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "nuts-discovery.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/nuts-discovery/templates/service.yaml
+++ b/charts/nuts-discovery/templates/service.yaml
@@ -6,7 +6,6 @@ metadata:
 {{ include "nuts-discovery.labels" . | indent 4 }}
 spec:
   type: {{ .Values.service.type }}
-  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/charts/nuts-discovery/templates/serviceaccount.yaml
+++ b/charts/nuts-discovery/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "nuts-discovery.serviceAccountName" . }}
+  labels:
+{{ include "nuts-discovery.labels" . | indent 4 }}
+{{- end -}}

--- a/charts/nuts-discovery/templates/tests/test-connection.yaml
+++ b/charts/nuts-discovery/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "nuts-discovery.fullname" . }}-test-connection"
+  labels:
+{{ include "nuts-discovery.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:  ['{{ include "nuts-discovery.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/nuts-discovery/values.yaml
+++ b/charts/nuts-discovery/values.yaml
@@ -32,8 +32,7 @@ serviceAccount:
 #  # runAsUser: 1000
 
 service:
-  type: LoadBalancer
-  loadBalancerIP: 34.90.36.239
+  type: NodePort
   port: 80
 
 ingress:

--- a/charts/nuts-discovery/values.yaml
+++ b/charts/nuts-discovery/values.yaml
@@ -1,0 +1,69 @@
+# Default values for nuts-discovery.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: nutsfoundation/nuts-discovery
+  tag: latest-dev
+  pullPolicy: Always
+
+#imagePullSecrets: []
+#nameOverride: ""
+#fullnameOverride: ""
+#
+serviceAccount:
+#  # Specifies whether a service account should be created
+  create: false
+#  # The name of the service account to use.
+#  # If not set and create is true, a name is generated using the fullname template
+#  name:
+
+#podSecurityContext: {}
+#  # fsGroup: 2000
+#
+#securityContext: {}
+#  # capabilities:
+#  #   drop:
+#  #   - ALL
+#  # readOnlyRootFilesystem: true
+#  # runAsNonRoot: true
+#  # runAsUser: 1000
+
+service:
+  type: LoadBalancer
+  loadBalancerIP: 34.90.36.239
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits:
+  #   cpu: 100m
+     memory: 512Mi
+  requests:
+  #   cpu: 100m
+     memory: 512Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/docs/pages/configuration/discovery.rst
+++ b/docs/pages/configuration/discovery.rst
@@ -60,3 +60,22 @@ Run the ``generate_keys.sh`` script to create a ``keys`` folder with all the nee
 .. sourcecode:: shell
 
   ./generate_keys.sh
+
+Deployment with Helm
+====================
+
+Installation
+-----------
+
+In the following examples we use the `development` namespace. The values.yaml currently contains values for development.
+
+.. sourcecode:: shell
+
+  helm install --debug --name discovery --namespace development charts/nuts-discovery -f charts/nuts-discovery/values.yaml
+
+Upgrading
+---------
+
+.. sourcecode:: shell
+
+  helm upgrade discovery -f charts/nuts-discovery/values.yaml charts/nuts-discovery --namespace development --recreate-pods

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Fri Nov 22 10:36:51 CET 2019
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/src/main/kotlin/nl/nuts/discovery/api/CertificateApi.kt
+++ b/src/main/kotlin/nl/nuts/discovery/api/CertificateApi.kt
@@ -37,7 +37,7 @@ import java.util.zip.ZipOutputStream
  * Certificate API for handling Certificate Signing Requests and returning an answer when signed.
  */
 @RestController
-@RequestMapping("/certificate", produces = arrayOf("*/*"), consumes = arrayOf("*/*"))
+@RequestMapping("/doorman/certificate", produces = arrayOf("*/*"), consumes = arrayOf("*/*"))
 class CertificateApi {
     val logger: Logger = LoggerFactory.getLogger(this.javaClass)
 

--- a/src/test/kotlin/nl/nuts/discovery/api/CertificateApiIntegrationTest.kt
+++ b/src/test/kotlin/nl/nuts/discovery/api/CertificateApiIntegrationTest.kt
@@ -54,14 +54,14 @@ class CertificateApiIntegrationTest {
 
     @Test
     fun `submitting with missing headers returns 400`() {
-        val response = testRestTemplate.postForEntity("/certificate", "", ByteArray::class.java)
+        val response = testRestTemplate.postForEntity("/doorman/certificate", "", ByteArray::class.java)
 
         assertEquals(400, response.statusCodeValue)
     }
 
     @Test
     fun `submitting an invalid CSR returns 400`() {
-        val response = testRestTemplate.exchange("/certificate", HttpMethod.POST, HttpEntity<Any>(headers()), ByteArray::class.java)
+        val response = testRestTemplate.exchange("/doorman/certificate", HttpMethod.POST, HttpEntity<Any>(headers()), ByteArray::class.java)
 
         assertEquals(400, response.statusCodeValue)
     }
@@ -73,7 +73,7 @@ class CertificateApiIntegrationTest {
 
         val entity = HttpEntity(req.encoded, headers())
 
-        val response = testRestTemplate.exchange("/certificate", HttpMethod.POST, entity, ByteArray::class.java)
+        val response = testRestTemplate.exchange("/doorman/certificate", HttpMethod.POST, entity, ByteArray::class.java)
 
         val bodyBytes = response.body
         assertNotNull(bodyBytes)
@@ -88,8 +88,8 @@ class CertificateApiIntegrationTest {
 
         val entity = HttpEntity(req.encoded, headers())
 
-        testRestTemplate.exchange("/certificate", HttpMethod.POST, entity, ByteArray::class.java)
-        val response = testRestTemplate.getForEntity("/certificate/$orgName", ByteArray::class.java)
+        testRestTemplate.exchange("/doorman/certificate", HttpMethod.POST, entity, ByteArray::class.java)
+        val response = testRestTemplate.getForEntity("/doorman/certificate/$orgName", ByteArray::class.java)
 
         assertEquals(204, response.statusCodeValue)
     }
@@ -101,9 +101,9 @@ class CertificateApiIntegrationTest {
 
         val entity = HttpEntity(req.encoded, headers())
 
-        testRestTemplate.exchange("/certificate", HttpMethod.POST, entity, ByteArray::class.java)
+        testRestTemplate.exchange("/doorman/certificate", HttpMethod.POST, entity, ByteArray::class.java)
         testRestTemplate.put("/admin/certificates/signrequests/O=Org,L=Gr,C=NL/approve", null)
-        val response = testRestTemplate.getForEntity("/certificate/O=Org,L=Gr,C=NL", ByteArray::class.java)
+        val response = testRestTemplate.getForEntity("/doorman/certificate/O=Org,L=Gr,C=NL", ByteArray::class.java)
 
         assertEquals(200, response.statusCodeValue)
         assertNotNull(response.body)
@@ -111,7 +111,7 @@ class CertificateApiIntegrationTest {
 
     @Test
     fun `an unknown certificate will return a 403`(){
-        val response = testRestTemplate.getForEntity("/certificate/O=Org,L=Gr,C=NL", ByteArray::class.java)
+        val response = testRestTemplate.getForEntity("/doorman/certificate/O=Org,L=Gr,C=NL", ByteArray::class.java)
         assertEquals(403, response.statusCodeValue)
         assertNull(response.body)
     }


### PR DESCRIPTION
Add Helm charts for easy deployment to a Kubernetes cluster.
For ingress routing, put all doorman relates APIs behind the /doorman/* path.