### PR TITLE
Publishing a node now uses the customNodeRepo

### DIFF
--- a/src/main/kotlin/nl/nuts/discovery/api/NetworkMapApi.kt
+++ b/src/main/kotlin/nl/nuts/discovery/api/NetworkMapApi.kt
@@ -34,6 +34,7 @@ import nl.nuts.discovery.store.entity.NetworkParameters
 import nl.nuts.discovery.store.entity.Node
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.http.CacheControl
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -57,6 +58,7 @@ import java.util.concurrent.TimeUnit
 class NetworkMapApi {
     val logger = LoggerFactory.getLogger(this.javaClass)
 
+    @Qualifier("customNodeRepository")
     @Autowired
     lateinit var nodeRepository: NodeRepository
 

--- a/src/test/kotlin/nl/nuts/discovery/api/NetworkMapApiIntegrationTest.kt
+++ b/src/test/kotlin/nl/nuts/discovery/api/NetworkMapApiIntegrationTest.kt
@@ -90,6 +90,14 @@ class NetworkMapApiIntegrationTest {
     }
 
     @Test
+    fun `publishing a valid node twice returns 200`() {
+        publishNode(subject)
+        val resp = publishNode(subject)
+
+        assertEquals(200, resp.statusCodeValue)
+    }
+
+    @Test
     fun `a published node is found in the network map`() {
         publishNotary()
         publishNode(subject)


### PR DESCRIPTION
Fixes #34

the custom node repo overrides current values.