### PR TITLE
Fix issued Nuts certificates to have entity's public key (instead of issuer's)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,6 @@ COPY --from=builder /opt/nuts/build/libs/nuts-discovery.jar /opt/nuts/discovery/
 COPY docker/application.properties /opt/nuts/discovery/conf/
 COPY docker/keys/* /opt/nuts/discovery/keys/
 CMD ["java", "-jar", "/opt/nuts/discovery/bin/nuts-discovery.jar", "--spring.config.location=file:/opt/nuts/discovery/conf/application.properties"]
+HEALTHCHECK --start-period=30s --timeout=5s --interval=10s \
+    CMD wget -q -O - http://localhost:8080/actuator/health | grep UP || exit 1
 EXPOSE 8080

--- a/README.rst
+++ b/README.rst
@@ -107,28 +107,36 @@ Before the *Nuts Discovery Service* can be started a few keys and certificates n
 
 By default it'll try to find the following keys at the given location. All files are in PEM format
 
-===================================     ====================    ================================================================================
-Key                                     Default                 Description
-===================================     ====================    ================================================================================
-nuts.discovery.rootCertPath             keys/root.crt           Corda root certificate path
-nuts.discovery.intermediateKeyPath      keys/doorman.key        Corda doorman key path, used to sign node csr's
-nuts.discovery.intermediateCertPath     keys/doorman.crt        Corda doorman certificate path
-nuts.discovery.networkMapCertPath       keys/network_map.crt    Corda network map certificate path
-nuts.discovery.networkMapKeyPath        keys/network_map.key    Corda network map key path, used to sign network parameters and nodeinfo objects
-nuts.discovery.flowHashes                                       Sha256 of jars for nl.nuts.consent.flow package (comma separated)
-nuts.discovery.contractHashes                                   Sha256 of jars for nl.nuts.consent.contract package (comma separated)
-nuts.discovery.autoAck                  false                   Automatically signs all signing requests
-===================================     ====================    ================================================================================
+===================================         ====================    ================================================================================
+Key                                         Default                 Description
+===================================         ====================    ================================================================================
+nuts.discovery.cordaRootCertPath            keys/root.crt           Corda root certificate path
+nuts.discovery.intermediateKeyPath          keys/doorman.key        Corda doorman key path, used to sign node csr's
+nuts.discovery.intermediateCertPath         keys/doorman.crt        Corda doorman certificate path
+nuts.discovery.networkMapCertPath           keys/network_map.crt    Corda network map certificate path
+nuts.discovery.networkMapKeyPath            keys/network_map.key    Corda network map key path, used to sign network parameters and nodeinfo objects
+nuts.discovery.nutsRootCertPath             keys/nuts_root.crt      Nuts root certificate path, trust anchor for p2p connections between nodes
+nuts.discovery.nutsCAKeyPath                keys/nuts_ca.key        Key path for Nuts CA, used to sign vendor certificates
+nuts.discovery.nutsCACertPath               keys/nuts_ca.crt        Cert path for Nuts CA, used to sign vendor certificates
+nuts.discovery.certificateValidityInDays                            Number of days issued Nuts certificates are valid
+nuts.discovery.flowHashes                                           Sha256 of jars for nl.nuts.consent.flow package (comma separated)
+nuts.discovery.contractHashes                                       Sha256 of jars for nl.nuts.consent.contract package (comma separated)
+nuts.discovery.autoAck                      false                   Automatically signs all signing requests
+===================================         ====================    ================================================================================
 
 These locations can be overriden by providing an alternative properties file with the following contents
 
 .. sourcecode:: properties
 
-    nuts.discovery.rootCertPath = keys/root.crt
+    nuts.discovery.cordaRootCertPath = keys/root.crt
     nuts.discovery.intermediateKeyPath = keys/doorman.key
     nuts.discovery.intermediateCertPath = keys/doorman.crt
     nuts.discovery.networkMapCertPath = keys/network_map.crt
     nuts.discovery.networkMapKeyPath = keys/network_map.key
+    nuts.discovery.nutsRootCertPath = keys/nuts_root.crt
+    nuts.discovery.nutsCAKeyPath = keys/nuts_ca.key
+    nuts.discovery.nutsCACertPath = keys/nuts_ca.crt
+    nuts.discovery.certificateValidityInDays = 1095
     nuts.discovery.contractHashes = 6ACDE387C0DF227A6C4ED77407B58E9103C2EA1A66796CE37BC497931F4E1631
     nuts.discovery.flowHashes = 5f60201e5f4e698300f3baf94dad1517a1314b4f406fd90610a78d798ffe972d
     nuts.discovery.autoAck = true

--- a/docker/application.properties
+++ b/docker/application.properties
@@ -17,10 +17,23 @@
 #
 #
 
-nuts.discovery.rootCertPath = /opt/nuts/discovery/keys/root.crt
+#
+# Corda configuration
+#
+nuts.discovery.cordaRootCertPath = /opt/nuts/discovery/keys/root.crt
 nuts.discovery.intermediateKeyPath = /opt/nuts/discovery/keys/doorman.key
 nuts.discovery.intermediateCertPath = /opt/nuts/discovery/keys/doorman.crt
 nuts.discovery.networkMapCertPath = /opt/nuts/discovery/keys/network_map.crt
 nuts.discovery.networkMapKeyPath = /opt/nuts/discovery/keys/network_map.key
+#
+# Network Authority configuration
+#
+nuts.discovery.nutsRootCertPath = /opt/nuts/discovery/keys/nuts_root.crt
+nuts.discovery.nutsCACertPath = /opt/nuts/discovery/keys/nuts_ca.crt
+nuts.discovery.nutsCAKeyPath = /opt/nuts/discovery/keys/nuts_ca.key
+nuts.discovery.certificateValidityInDays = 1095
+#
+# Misc. configuration
+#
 spring.jackson.serialization.FAIL_ON_EMPTY_BEANS=false
 nuts.discovery.autoAck = true

--- a/docs/pages/configuration/discovery.rst
+++ b/docs/pages/configuration/discovery.rst
@@ -9,21 +9,22 @@ Before the *Nuts Discovery Service* can be started a few keys and certificates n
 
 By default it'll try to find the following keys at the given location. All files are in PEM format
 
-===================================     ====================    ================================================================================
-Key                                     Default                 Description
-===================================     ====================    ================================================================================
-nuts.discovery.cordaRootCertPath        keys/root.crt           Corda root certificate path
-nuts.discovery.intermediateKeyPath      keys/doorman.key        Corda doorman key path, used to sign node csr's
-nuts.discovery.intermediateCertPath     keys/doorman.crt        Corda doorman certificate path
-nuts.discovery.networkMapCertPath       keys/network_map.crt    Corda network map certificate path
-nuts.discovery.networkMapKeyPath        keys/network_map.key    Corda network map key path, used to sign network parameters and nodeinfo objects
-nuts.discovery.nutsRootCertPath         keys/nuts_root.crt      Nuts root certificate path, trust anchor for p2p connections between nodes
-nuts.discovery.nutsCAKeyPath            keys/nuts_ca.key        Key path for Nuts CA, used to sign vendor certificates
-nuts.discovery.nutsCACertPath           keys/nuts_ca.crt        Cert path for Nuts CA, used to sign vendor certificates
-nuts.discovery.flowHashes                                       Sha256 of jars for nl.nuts.consent.flow package (comma separated)
-nuts.discovery.contractHashes                                   Sha256 of jars for nl.nuts.consent.contract package (comma separated)
-nuts.discovery.autoAck                  false                   Automatically signs all signing requests
-===================================     ====================    ================================================================================
+===================================         ====================    ================================================================================
+Key                                         Default                 Description
+===================================         ====================    ================================================================================
+nuts.discovery.cordaRootCertPath            keys/root.crt           Corda root certificate path
+nuts.discovery.intermediateKeyPath          keys/doorman.key        Corda doorman key path, used to sign node csr's
+nuts.discovery.intermediateCertPath         keys/doorman.crt        Corda doorman certificate path
+nuts.discovery.networkMapCertPath           keys/network_map.crt    Corda network map certificate path
+nuts.discovery.networkMapKeyPath            keys/network_map.key    Corda network map key path, used to sign network parameters and nodeinfo objects
+nuts.discovery.nutsRootCertPath             keys/nuts_root.crt      Nuts root certificate path, trust anchor for p2p connections between nodes
+nuts.discovery.nutsCAKeyPath                keys/nuts_ca.key        Key path for Nuts CA, used to sign vendor certificates
+nuts.discovery.nutsCACertPath               keys/nuts_ca.crt        Cert path for Nuts CA, used to sign vendor certificates
+nuts.discovery.certificateValidityInDays                            Number of days issued Nuts certificates are valid
+nuts.discovery.flowHashes                                           Sha256 of jars for nl.nuts.consent.flow package (comma separated)
+nuts.discovery.contractHashes                                       Sha256 of jars for nl.nuts.consent.contract package (comma separated)
+nuts.discovery.autoAck                      false                   Automatically signs all signing requests
+===================================         ====================    ================================================================================
 
 These locations can be overriden by providing an alternative properties file with the following contents
 
@@ -37,6 +38,7 @@ These locations can be overriden by providing an alternative properties file wit
     nuts.discovery.nutsRootCertPath = keys/nuts_root.crt
     nuts.discovery.nutsCAKeyPath = keys/nuts_ca.key
     nuts.discovery.nutsCACertPath = keys/nuts_ca.crt
+    nuts.discovery.certificateValidityInDays = 1095
     nuts.discovery.contractHashes = 6ACDE387C0DF227A6C4ED77407B58E9103C2EA1A66796CE37BC497931F4E1631
     nuts.discovery.flowHashes = 5f60201e5f4e698300f3baf94dad1517a1314b4f406fd90610a78d798ffe972d
     nuts.discovery.autoAck = true

--- a/src/main/kotlin/nl/nuts/discovery/service/CertificatesApiServiceImpl.kt
+++ b/src/main/kotlin/nl/nuts/discovery/service/CertificatesApiServiceImpl.kt
@@ -207,7 +207,7 @@ class CertificatesApiServiceImpl : AbstractCertificatesService(), CertificatesAp
             Date(System.currentTimeMillis()),
             Date(System.currentTimeMillis() + validity),
             pkcs10.subject,
-            issuer.publicKey
+            pkcs10.publicKey
         ).addExtension(
             Extension.basicConstraints,
             true,


### PR DESCRIPTION
PR is based on https://github.com/nuts-foundation/nuts-discovery/pull/57 (so that one should be merged first).